### PR TITLE
FixMe CORS bugfix

### DIFF
--- a/server/instances.py
+++ b/server/instances.py
@@ -24,7 +24,7 @@ if server_mode != "setup" and server_mode is not None:
 
     sio: AsyncServer = AsyncServer(
         async_mode="asgi",
-        cors_allowed_origins=["*"],
+        cors_allowed_origins="*",
         logger=True if debug == "true" else False,
         client_manager=AsyncRedisManager(redis_url),
     )

--- a/server/src/utils/fix.py
+++ b/server/src/utils/fix.py
@@ -17,8 +17,8 @@ class Application:
             message = f"FixMe: {timeout}"
             logger.info(f"Broadcast: {message}")
             await self.sio.emit("fixme", message)
-            timeout += 10
-            await asyncio.sleep(10)
+            timeout += 30
+            await asyncio.sleep(30)
 
     def broadcast(self, message):
         if hasattr(self, "sio"):

--- a/utils/stop.sh
+++ b/utils/stop.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 echo "[$(date)] Stopping Doctor Octopus services..."
+services=("notification" "server" "client" "fixme")  # Stops in reverse order
 
 # Function to safely stop a service
 stop_service() {
@@ -76,7 +77,6 @@ stop_service() {
 }
 
 # Stop all services
-services=("notification" "server" "client")  # Stop in reverse order
 stopped_count=0
 failed_count=0
 
@@ -105,7 +105,7 @@ done
 
 # Show final status
 echo "[$(date)] Final process check:"
-for service in client server notification; do
+for service in "${services[@]}"; do
     if [ -f "logs/${service}.pid" ]; then
         pid=$(cat "logs/${service}.pid")
         if kill -0 "$pid" 2>/dev/null; then


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the server and utility scripts. The most notable changes include adjusting the CORS configuration for the Socket.IO server, modifying the timing logic in the fix utility, and updating the stop script to include the "fixme" service in its operations.

**Server and Networking Improvements:**

* Changed the `cors_allowed_origins` parameter in the `AsyncServer` initialization from a list to a string (`"*"`), aligning with the expected format for allowing all origins.

**Utility Script Updates:**

* Updated the `utils/stop.sh` script to include the `"fixme"` service in the list of services to be stopped, ensuring it is handled alongside other core services. [[1]](diffhunk://#diff-7d72dc96f67f32a24286f63fa9d1e3b8dfcab23d870e51f1b5089c8b45300be5R4) [[2]](diffhunk://#diff-7d72dc96f67f32a24286f63fa9d1e3b8dfcab23d870e51f1b5089c8b45300be5L79)
* Modified the final process check loop in `stop.sh` to iterate over the updated `services` array, so the status of all relevant services, including `"fixme"`, is reported.

**Timing and Broadcast Logic:**

* Increased the timeout increment and sleep duration from 10 seconds to 30 seconds in the `connect` method of the fix utility, reducing the frequency of broadcast messages.